### PR TITLE
destory session when refrsh_token expired

### DIFF
--- a/frontend/app/auth.ts
+++ b/frontend/app/auth.ts
@@ -42,6 +42,10 @@ export const {
           return token;
         }
       }
+      if ((token.refreshTokenExpiresAt as number) < new Date().getTime() / 1000)
+      {
+        throw new Error("Refresh token expired. Please Login again");
+      }
       if ((token.expiresAt as number) < new Date().getTime() / 1000) {
         const client = await getUnAuthClient();
         const { data, error } = await client.POST(

--- a/frontend/app/auth.ts
+++ b/frontend/app/auth.ts
@@ -42,10 +42,6 @@ export const {
           return token;
         }
       }
-      if ((token.refreshTokenExpiresAt as number) < new Date().getTime() / 1000)
-      {
-        throw new Error("Refresh token expired. Please Login again");
-      }
       if ((token.expiresAt as number) < new Date().getTime() / 1000) {
         const client = await getUnAuthClient();
         const { data, error } = await client.POST(

--- a/gateway/app/appaccount/routes/auths.py
+++ b/gateway/app/appaccount/routes/auths.py
@@ -58,7 +58,7 @@ def post_refresh(request, payload: RefreshPostIn):
     if session is None:
         return 401, None
     if session.is_refresh_token_expired():
-        session.delete()
+        session.destroy()
         return 401, None
     session.refresh(refresh_token=payload.refresh_token)
     ret = {

--- a/gateway/app/appaccount/routes/auths.py
+++ b/gateway/app/appaccount/routes/auths.py
@@ -58,6 +58,7 @@ def post_refresh(request, payload: RefreshPostIn):
     if session is None:
         return 401, None
     if session.is_refresh_token_expired():
+        session.destory()
         return 401, None
     session.refresh(refresh_token=payload.refresh_token)
     ret = {

--- a/gateway/app/appaccount/routes/auths.py
+++ b/gateway/app/appaccount/routes/auths.py
@@ -58,7 +58,7 @@ def post_refresh(request, payload: RefreshPostIn):
     if session is None:
         return 401, None
     if session.is_refresh_token_expired():
-        session.destory()
+        session.delete()
         return 401, None
     session.refresh(refresh_token=payload.refresh_token)
     ret = {


### PR DESCRIPTION
When refresh_token expired, user are forced logout on Browser and have to signIn again.
But AuthSession is not destory on the Database
Changes:
- delete expired session when refresh_token expired